### PR TITLE
Add partner registration service and approval guard

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -26,6 +26,7 @@ import { PartnersOffersComponent } from './features/b2b/partners/offers/partners
 import { PartnersOfferDetailsComponent } from './features/b2b/partners/offers/partners-offer-details.component';
 import { PartnersContactComponent } from './features/b2b/partners/contact/partners-contact.component';
 import { B2bLayoutComponent } from './features/b2b/shared/layout/b2b-layout.component';
+import { CompanyApprovedGuard } from './guards/company-approved.guard';
 import { CheckoutComponent } from './features/b2c/checkout/checkout.component';
 import { OrderReviewComponent } from './features/b2c/checkout/steps/order-review/order-review.component';
 import { ShippingComponent } from './features/b2c/checkout/steps/shipping/shipping.component';
@@ -108,9 +109,9 @@ export const routes: Routes = [
         children: [
             { path: '', component: PartnersComponent },
             { path: 'register', component: PartnersRegisterComponent },
-            { path: 'products', component: PartnersProductsComponent },
-            { path: 'offers', component: PartnersOffersComponent },
-            { path: 'offers/:id', component: PartnersOfferDetailsComponent },
+            { path: 'products', component: PartnersProductsComponent, canActivate: [CompanyApprovedGuard] },
+            { path: 'offers', component: PartnersOffersComponent, canActivate: [CompanyApprovedGuard] },
+            { path: 'offers/:id', component: PartnersOfferDetailsComponent, canActivate: [CompanyApprovedGuard] },
             { path: 'contact', component: PartnersContactComponent },
         ]
     },

--- a/src/app/features/b2b/partners/register/partners-register.component.ts
+++ b/src/app/features/b2b/partners/register/partners-register.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angula
 import { Router, RouterModule } from '@angular/router';
 import { TranslatePipe } from '../../../../shared/pipes/translate.pipe';
 import { CompanyRegistrationData } from '../../../../shared/models/company.model';
+import { PartnerRegistrationService } from '../services/partner-registration.service';
 
 @Component({
     selector: 'app-partners-register',
@@ -349,7 +350,8 @@ export class PartnersRegisterComponent {
 
     constructor(
         private fb: FormBuilder,
-        public router: Router
+        public router: Router,
+        private registrationService: PartnerRegistrationService
     ) {
         this.registrationForm = this.fb.group({
             // Personal Information
@@ -432,15 +434,17 @@ export class PartnersRegisterComponent {
 
             const formData = this.registrationForm.value as CompanyRegistrationData;
 
-            // Simulate API call
-            setTimeout(() => {
-                console.log('Partner registration data:', formData);
+            this.registrationService.registerPartner(formData).then(result => {
                 this.isSubmitting = false;
-                this.currentStep = 3;
-            }, 2000);
+                if (!result.error) {
+                    this.currentStep = 3;
+                } else {
+                    console.error('Partner registration failed:', result.error);
+                }
+            });
         } else {
             // Mark all fields as touched to show validation errors
             this.registrationForm.markAllAsTouched();
         }
     }
-} 
+}

--- a/src/app/features/b2b/partners/services/partner-registration.service.ts
+++ b/src/app/features/b2b/partners/services/partner-registration.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import { SupabaseService } from '../../../../services/supabase.service';
+import { CompanyRegistrationData } from '../../../../shared/models/company.model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class PartnerRegistrationService {
+    constructor(private supabase: SupabaseService) {}
+
+    async registerPartner(data: CompanyRegistrationData): Promise<{ error?: string }> {
+        try {
+            const response = await this.supabase.signUp({
+                email: data.email,
+                password: data.password,
+                firstName: data.firstName,
+                lastName: data.lastName,
+                phone: data.phoneNumber || undefined
+            });
+
+            if (response.error || !response.user) {
+                return { error: response.error || 'Registration failed' };
+            }
+
+            const { error: companyError } = await this.supabase.client
+                .from('companies')
+                .insert({
+                    contact_person_id: response.user.id,
+                    contact_person_name: `${data.firstName} ${data.lastName}`,
+                    first_name: data.firstName,
+                    last_name: data.lastName,
+                    email: data.email,
+                    phone_number: data.phoneNumber,
+                    address: data.address,
+                    company_name: data.companyName,
+                    tax_number: data.taxNumber,
+                    company_address: data.companyAddress,
+                    company_phone: data.companyPhone,
+                    company_email: data.companyEmail,
+                    website: data.website,
+                    business_type: data.businessType,
+                    years_in_business: data.yearsInBusiness,
+                    annual_revenue: data.annualRevenue,
+                    number_of_employees: data.numberOfEmployees,
+                    description: data.description
+                });
+
+            if (companyError) {
+                return { error: companyError.message };
+            }
+
+            return {};
+        } catch (err: any) {
+            return { error: err.message };
+        }
+    }
+}

--- a/src/app/guards/company-approved.guard.ts
+++ b/src/app/guards/company-approved.guard.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { SupabaseService } from '../services/supabase.service';
+import { Observable, from, of } from 'rxjs';
+import { switchMap, map, catchError, take } from 'rxjs/operators';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class CompanyApprovedGuard implements CanActivate {
+    constructor(private supabase: SupabaseService, private router: Router) {}
+
+    canActivate(): Observable<boolean | UrlTree> {
+        return this.supabase.isAuthenticated().pipe(
+            take(1),
+            switchMap(isAuth => {
+                if (!isAuth) {
+                    return of(this.router.createUrlTree(['/login']));
+                }
+                return from(this.supabase.getSession()).pipe(
+                    switchMap(session => {
+                        const userId = session?.user?.id;
+                        if (!userId) {
+                            return of(this.router.createUrlTree(['/login']));
+                        }
+                        return from(
+                            this.supabase.client
+                                .from('companies')
+                                .select('status')
+                                .eq('contact_person_id', userId)
+                                .single()
+                        ).pipe(
+                            map(({ data }) => {
+                                if (data && data.status === 'approved') {
+                                    return true;
+                                }
+                                return this.router.createUrlTree(['/partners/register']);
+                            }),
+                            catchError(() => of(this.router.createUrlTree(['/partners/register'])))
+                        );
+                    })
+                );
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PartnerRegistrationService` to sign up a user and create a company record
- guard B2B partner routes with new `CompanyApprovedGuard`
- wire registration form to call new service

## Testing
- `npm test` *(fails: `ng` not found)*
- `npm run build` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b10a1784832ca689d232714b1ba3